### PR TITLE
C++11 requires a mandatory space when concatenating string literals

### DIFF
--- a/common.h
+++ b/common.h
@@ -48,15 +48,15 @@
      esyslog("curl_easy_perform() [%s,%d] failed: %s (%d)",  __FILE__, __LINE__, curl_easy_strerror(res), res); \
      }
 
-#define ERROR_IF_FUNC(exp, errstr, func, ret)                \
-  do {                                                       \
-     if (exp) {                                              \
-        char tmp[64];                                        \
-        esyslog("[%s,%d]: "errstr": %s", __FILE__, __LINE__, \
-                strerror_r(errno, tmp, sizeof(tmp)));        \
-        func;                                                \
-        ret;                                                 \
-        }                                                    \
+#define ERROR_IF_FUNC(exp, errstr, func, ret)                  \
+  do {                                                         \
+     if (exp) {                                                \
+        char tmp[64];                                          \
+        esyslog("[%s,%d]: " errstr ": %s", __FILE__, __LINE__, \
+                strerror_r(errno, tmp, sizeof(tmp)));          \
+        func;                                                  \
+        ret;                                                   \
+        }                                                      \
   } while (0)
 
 


### PR DESCRIPTION
This issue came up with GCC6. Concatenating string literals snow requires a space in between.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811948