### PR TITLE
Source filtering

### DIFF
--- a/README
+++ b/README
@@ -52,9 +52,10 @@ separated list of "<ipaddress>|<model>|<description>" entries. The model
 consists of a DVB system (DVBS2,DVBT2,DVBT,DVBC) and number of available
 frontends separated by a hyphen:
 
-vdr -P 'satip -s <ipaddress>|<model>|<description>;...'
+vdr -P 'satip -s <ipaddress>[:<port>]|<model>[:<filter>]|<description>;...'
 vdr -P 'satip -s 192.168.0.1|DVBS2-2,DVBT2-2|OctopusNet'
 vdr -P 'satip -s 192.168.0.1|DVBS2-4|OctopusNet;192.168.0.2|DVBT2-4|minisatip'
+vdr -P 'satip -s 192.168.0.1:554|DVBS2-2:S19.2E|OctopusNet;192.168.0.2:8554|DVBS2-4:S19.2E,S1W|minisatip'
 
 The plugin accepts a "--portrange" (-p) command-line parameter, that can
 be used to manually specify the RTP & RTCP port range and therefore

--- a/discover.c
+++ b/discover.c
@@ -32,7 +32,7 @@ bool cSatipDiscover::Initialize(cSatipDiscoverServers *serversP)
   if (instanceS) {
        if (serversP) {
           for (cSatipDiscoverServer *s = serversP->First(); s; s = serversP->Next(s))
-              instanceS->AddServer(s->IpAddress(), s->IpPort(), s->Model(), s->Description());
+              instanceS->AddServer(s->IpAddress(), s->IpPort(), s->Model(), s->Filters(), s->Description());
           }
      else
         instanceS->Activate();
@@ -271,12 +271,12 @@ void cSatipDiscover::ParseDeviceInfo(const char *addrP, const int portP)
         model = modelNode.text().as_string("DVBS2-1");
      }
 #endif
-  AddServer(addrP, portP, model, desc);
+  AddServer(addrP, portP, model, NULL, desc);
 }
 
-void cSatipDiscover::AddServer(const char *addrP, const int portP, const char *modelP, const char * descP)
+void cSatipDiscover::AddServer(const char *addrP, const int portP, const char *modelP, const char *filtersP, const char *descP)
 {
-  debug1("%s (%s, %d, %s, %s)", __PRETTY_FUNCTION__, addrP, portP, modelP, descP);
+  debug1("%s (%s, %d, %s, %s, %s)", __PRETTY_FUNCTION__, addrP, portP, modelP, filtersP, descP);
   cMutexLock MutexLock(&mutexM);
   if (SatipConfig.GetUseSingleModelServers() && modelP && !isempty(modelP)) {
      int n = 0;
@@ -285,9 +285,9 @@ void cSatipDiscover::AddServer(const char *addrP, const int portP, const char *m
      while (r) {
            r = skipspace(r);
            cString desc = cString::sprintf("%s #%d", !isempty(descP) ? descP : "MyBrokenHardware", n++);
-           cSatipServer *tmp = new cSatipServer(addrP, portP, r, desc);
+           cSatipServer *tmp = new cSatipServer(addrP, portP, r, filtersP, desc);
            if (!serversM.Update(tmp)) {
-              info("Adding server '%s|%s|%s' CI: %s Quirks: %s", tmp->Address(), tmp->Model(), tmp->Description(), tmp->HasCI() ? "yes" : "no", tmp->HasQuirk() ? tmp->Quirks() : "none");
+              info("Adding server '%s|%s|%s' Filters: %s CI: %s Quirks: %s", tmp->Address(), tmp->Model(), tmp->Description(), !isempty(tmp->Filters()) ? tmp->Filters() : "none", tmp->HasCI() ? "yes" : "no", tmp->HasQuirk() ? tmp->Quirks() : "none");
               serversM.Add(tmp);
               }
            else
@@ -297,9 +297,9 @@ void cSatipDiscover::AddServer(const char *addrP, const int portP, const char *m
      FREE_POINTER(p);
      }
   else {
-     cSatipServer *tmp = new cSatipServer(addrP, portP, modelP, descP);
+     cSatipServer *tmp = new cSatipServer(addrP, portP, modelP, filtersP, descP);
      if (!serversM.Update(tmp)) {
-        info("Adding server '%s|%s|%s' CI: %s Quirks: %s", tmp->Address(), tmp->Model(), tmp->Description(), tmp->HasCI() ? "yes" : "no", tmp->HasQuirk() ? tmp->Quirks() : "none");
+        info("Adding server '%s|%s|%s' Filters: %s CI: %s Quirks: %s", tmp->Address(), tmp->Model(), tmp->Description(), !isempty(tmp->Filters()) ? tmp->Filters() : "none", tmp->HasCI() ? "yes" : "no", tmp->HasQuirk() ? tmp->Quirks() : "none");
         serversM.Add(tmp);
         }
      else

--- a/discover.h
+++ b/discover.h
@@ -25,14 +25,16 @@ private:
   cString ipAddressM;
   cString descriptionM;
   cString modelM;
+  cString filtersM;
 public:
-  cSatipDiscoverServer(const char *ipAddressP, const int ipPortP, const char *modelP, const char *descriptionP)
+  cSatipDiscoverServer(const char *ipAddressP, const int ipPortP, const char *modelP, const char *filtersP, const char *descriptionP)
   {
-    ipAddressM = ipAddressP; ipPortM = ipPortP; modelM = modelP; descriptionM = descriptionP;
+    ipAddressM = ipAddressP; ipPortM = ipPortP; modelM = modelP; filtersM = filtersP; descriptionM = descriptionP;
   }
   int IpPort(void)              { return ipPortM; }
   const char *IpAddress(void)   { return *ipAddressM; }
   const char *Model(void)       { return *modelM; }
+  const char *Filters(void)     { return *filtersM; }
   const char *Description(void) { return *descriptionM; }
 };
 
@@ -65,7 +67,7 @@ private:
   void Deactivate(void);
   int ParseRtspPort(void);
   void ParseDeviceInfo(const char *addrP, const int portP);
-  void AddServer(const char *addrP, const int portP, const char *modelP, const char *descP);
+  void AddServer(const char *addrP, const int portP, const char *modelP, const char *filtersP, const char *descP);
   void Fetch(const char *urlP);
   // constructor
   cSatipDiscover();

--- a/satip.c
+++ b/satip.c
@@ -84,7 +84,7 @@ const char *cPluginSatip::CommandLineHelp(void)
   // Return a string that describes all known command line options.
   return "  -d <num>, --devices=<number>  set number of devices to be created\n"
          "  -t <mode>, --trace=<mode>     set the tracing mode\n"
-         "  -s <ipaddr>|<model>|<desc>, --server=<ipaddr1>|<model1>|<desc1>;<ipaddr2:port>|<model2>|<desc2>\n"
+         "  -s <ipaddr>|<model>|<desc>, --server=<ipaddr1>|<model1>|<desc1>;<ipaddr2>:<port>|<model2>:<filter>|<desc2>\n"
          "                                define hard-coded SAT>IP server(s)\n"
          "  -D, --detach                  set the detached mode on\n"
          "  -S, --single                  set the single model server mode on\n"
@@ -232,7 +232,7 @@ void cPluginSatip::ParseServer(const char *paramP)
   while (r) {
         r = skipspace(r);
         debug3("%s server[%d]=%s", __PRETTY_FUNCTION__, n, r);
-        cString serverAddr, serverModel, serverDescription;
+        cString serverAddr, serverModel, serverFilters, serverDescription;
         int serverPort = SATIP_DEFAULT_RTSP_PORT;
         int n2 = 0;
         char *s2, *p2 = r;
@@ -251,7 +251,14 @@ void cPluginSatip::ParseServer(const char *paramP)
                           }
                           break;
                      case 1:
+                          {
                           serverModel = r2;
+                          char *r3 = strchr(r2, ':');
+                          if (r3) {
+                             serverFilters = r3 + 1;
+                             serverModel = serverModel.Truncate(r3 - r2);
+                             }
+                          }
                           break;
                      case 2:
                           serverDescription = r2;
@@ -262,10 +269,10 @@ void cPluginSatip::ParseServer(const char *paramP)
               r2 = strtok_r(NULL, "|", &s2);
               }
         if (*serverAddr && *serverModel && *serverDescription) {
-           debug1("%s ipaddr=%s port=%d model=%s desc=%s", __PRETTY_FUNCTION__, *serverAddr, serverPort, *serverModel, *serverDescription);
+           debug1("%s ipaddr=%s port=%d model=%s (%s) desc=%s", __PRETTY_FUNCTION__, *serverAddr, serverPort, *serverModel, *serverFilters, *serverDescription);
            if (!serversM)
               serversM = new cSatipDiscoverServers();
-           serversM->Add(new cSatipDiscoverServer(*serverAddr, serverPort, *serverModel, *serverDescription));
+           serversM->Add(new cSatipDiscoverServer(*serverAddr, serverPort, *serverModel, *serverFilters, *serverDescription));
            }
         ++n;
         r = strtok_r(NULL, ";", &s);

--- a/server.h
+++ b/server.h
@@ -54,17 +54,23 @@ private:
     eSatipFrontendDVBC2,
     eSatipFrontendCount
   };
+  enum {
+    eSatipMaxSourceFilters = 16
+  };
   cString addressM;
   cString modelM;
+  cString filtersM;
   cString descriptionM;
   cString quirksM;
   cSatipFrontends frontendsM[eSatipFrontendCount];
+  int sourceFiltersM[eSatipMaxSourceFilters];
   int portM;
   int quirkM;
   bool hasCiM;
   bool activeM;
   time_t createdM;
   cTimeMs lastSeenM;
+  bool IsValidSource(int sourceP);
 
 public:
   enum eSatipQuirk {
@@ -75,7 +81,7 @@ public:
     eSatipQuirkRtpOverTcp = 0x08,
     eSatipQuirkMask       = 0x0F
   };
-  cSatipServer(const char *addressP, const int portP, const char *modelP, const char *descriptionP);
+  cSatipServer(const char *addressP, const int portP, const char *modelP, const char *filtersP, const char *descriptionP);
   virtual ~cSatipServer();
   virtual int Compare(const cListObject &listObjectP) const;
   bool Assign(int deviceIdP, int sourceP, int systemP, int transponderP);
@@ -91,6 +97,7 @@ public:
   void Activate(bool onOffP)    { activeM = onOffP; }
   const char *Address(void)     { return *addressM; }
   const char *Model(void)       { return *modelM; }
+  const char *Filters(void)     { return *filtersM; }
   const char *Description(void) { return *descriptionM; }
   const char *Quirks(void)      { return *quirksM; }
   int Port(void)                { return portM; }


### PR DESCRIPTION
Source filtering is configured via command-line parameter: model string can be extended with a semicolon and add white-listed source strings separated with commas after it:
`--server=192.168.1.21|DVBS2-4:S19.2E|OctopusNet1192.168.1.20|DVBS2-2,DVBT2-2:S28.2E,T|OctopusNet2`