### PR TITLE
do source-filtering in cSatipServer::Assign()

### DIFF
--- a/server.c
+++ b/server.c
@@ -206,6 +206,9 @@ int cSatipServer::Compare(const cListObject &listObjectP) const
 
 bool cSatipServer::Assign(int deviceIdP, int sourceP, int systemP, int transponderP)
 {
+  if (!IsValidSource(sourceP))
+	  return false;
+
   bool result = false;
   if (cSource::IsType(sourceP, 'S'))
      result = frontendsM[eSatipFrontendDVBS2].Assign(deviceIdP, transponderP);


### PR DESCRIPTION
We also need to check for a valid source in the Assign()-function, not only in Match(). I even think we do not need to check in Match() at all.

This small commit fixes the required behavior.