### PR TITLE
fix gcc7 compiling

### DIFF
--- a/satip.c
+++ b/satip.c
@@ -5,6 +5,7 @@
  *
  */
 
+#include <ctype.h>
 #include <getopt.h>
 #include <vdr/plugin.h>
 #include "common.h"


### PR DESCRIPTION
-fixes gcc7 compiling of the plugin (build tested against the vdr-2.2.x branch - we have currently no 2.3 due missing plugins)

pls feel free to close or change the pr in any way that is necessary 