### PR TITLE
Fix rofafor#65 RTSP streams not disconnected on error

### DIFF
--- a/tuner.c
+++ b/tuner.c
@@ -120,12 +120,15 @@ void cSatipTuner::Action(void)
                break;
           case tsSet:
                debug4("%s: tsSet [device %d]", __PRETTY_FUNCTION__, deviceIdM);
+               // some devices require TEARDOWN before new PLAY command
                Disconnect();
                if (Connect()) {
                   tuning.Set(eTuningTimeoutMs);
                   RequestState(tsTuned, smInternal);
                   UpdatePids(true);
                   }
+               else
+                  Disconnect();
                break;
           case tsTuned:
                debug4("%s: tsTuned [device %d]", __PRETTY_FUNCTION__, deviceIdM);

--- a/tuner.c
+++ b/tuner.c
@@ -120,13 +120,12 @@ void cSatipTuner::Action(void)
                break;
           case tsSet:
                debug4("%s: tsSet [device %d]", __PRETTY_FUNCTION__, deviceIdM);
+               Disconnect();
                if (Connect()) {
                   tuning.Set(eTuningTimeoutMs);
                   RequestState(tsTuned, smInternal);
                   UpdatePids(true);
                   }
-               else
-                  Disconnect();
                break;
           case tsTuned:
                debug4("%s: tsTuned [device %d]", __PRETTY_FUNCTION__, deviceIdM);


### PR DESCRIPTION
This patch fixes the issue for me. Since `tsSet` state can only happen when already connected it should be safe to disconnect first.