### PR TITLE
Add DeviceHooksProvidesEIT() from vdr-2.4.3+

### DIFF
--- a/device.c
+++ b/device.c
@@ -309,7 +309,7 @@ bool cSatipDevice::ProvidesChannel(const cChannel *channelP, int priorityP, bool
 
 bool cSatipDevice::ProvidesEIT(void) const
 {
-#if VDRVERSNUM < 20404
+#if defined(APIVERSNUM) && APIVERSNUM < 20404
   return (SatipConfig.GetEITScan());
 #else
   return (SatipConfig.GetEITScan()) && DeviceHooksProvidesEIT();

--- a/device.c
+++ b/device.c
@@ -309,7 +309,7 @@ bool cSatipDevice::ProvidesChannel(const cChannel *channelP, int priorityP, bool
 
 bool cSatipDevice::ProvidesEIT(void) const
 {
-#if defined(APIVERSNUM) && APIVERSNUM < 20404
+#if defined(APIVERSNUM) && APIVERSNUM < 20403
   return (SatipConfig.GetEITScan());
 #else
   return (SatipConfig.GetEITScan()) && DeviceHooksProvidesEIT();

--- a/device.c
+++ b/device.c
@@ -309,7 +309,11 @@ bool cSatipDevice::ProvidesChannel(const cChannel *channelP, int priorityP, bool
 
 bool cSatipDevice::ProvidesEIT(void) const
 {
+#if VDRVERSNUM < 20404
   return (SatipConfig.GetEITScan());
+#else
+  return (SatipConfig.GetEITScan()) && DeviceHooksProvidesEIT();
+#endif
 }
 
 int cSatipDevice::NumProvidedSystems(void) const


### PR DESCRIPTION
Between vdr-2.4.2 and 2.4.4 (with 2.4.3 never released), a new feature was added to cDeviceHook to interact with a devices EIT data feature.

However, it requires support from the plugin in bool cSatipDevice::ProvidesEit(void) const, to check if another cDeviceHook based Plugin tries to control VDR's access to Eit data for such a device.

Adding support for it.
For reference, pls find an implementation in bool cDvbDevice::ProvidesEIT(void) const in vdr/dvbdevice.c.
