### PR TITLE
HasLock(): add timeout feature

### DIFF
--- a/device.c
+++ b/device.c
@@ -450,16 +450,15 @@ bool cSatipDevice::HasLock(int timeoutMsP) const
   debug16("%s (%d) [device %d]", __PRETTY_FUNCTION__, timeoutMsP, deviceIndexM);
   if (timeoutMsP <= 0)
      return (pTunerM && pTunerM->HasLock());
-  else {
-     const int intervalMs = 100;
 
-     for (int t = 0; t < timeoutMsP; t += intervalMs) {
-         if (HasLock(0))
-            return true;
-         cCondWait::SleepMs(intervalMs);
-         }
-     return HasLock(0);
-     }
+  cTimeMs timer(timeoutMsP);
+
+  while (!timer.TimedOut()) {
+        if (HasLock(0))
+           return true;
+        cCondWait::SleepMs(100);
+        }
+  return HasLock(0);
 }
 
 bool cSatipDevice::HasInternalCam(void)

--- a/device.c
+++ b/device.c
@@ -448,17 +448,15 @@ void cSatipDevice::CloseDvr(void)
 bool cSatipDevice::HasLock(int timeoutMsP) const
 {
   debug16("%s (%d) [device %d]", __PRETTY_FUNCTION__, timeoutMsP, deviceIndexM);
-  if (timeoutMsP <= 0)
-     return (pTunerM && pTunerM->HasLock());
-
-  cTimeMs timer(timeoutMsP);
-
-  while (!timer.TimedOut()) {
-        if (HasLock(0))
-           return true;
-        cCondWait::SleepMs(100);
-        }
-  return HasLock(0);
+  if (timeoutMsP > 0) {
+     cTimeMs timer(timeoutMsP);
+     while (!timer.TimedOut()) {
+           if (pTunerM && pTunerM->HasLock())
+              return true;
+           cCondWait::SleepMs(100);
+           }
+     }
+  return (pTunerM && pTunerM->HasLock());
 }
 
 bool cSatipDevice::HasInternalCam(void)

--- a/device.c
+++ b/device.c
@@ -448,7 +448,18 @@ void cSatipDevice::CloseDvr(void)
 bool cSatipDevice::HasLock(int timeoutMsP) const
 {
   debug16("%s (%d) [device %d]", __PRETTY_FUNCTION__, timeoutMsP, deviceIndexM);
-  return (pTunerM && pTunerM->HasLock());
+  if (timeoutMsP <= 0)
+     return (pTunerM && pTunerM->HasLock());
+  else {
+     const int intervalMs = 100;
+
+     for (int t = 0; t < timeoutMsP; t += intervalMs) {
+         if (HasLock(0))
+            return true;
+         cCondWait::SleepMs(intervalMs);
+         }
+     return HasLock(0);
+     }
 }
 
 bool cSatipDevice::HasInternalCam(void)


### PR DESCRIPTION
**bool cSatipDevice::HasLock(int timeoutMsP)** didnt implement timeout up to now.

Due to that, a caller expecting a lock after tune within timeoutMsP milliseconds
may fail and get a 'no lock' answer - even if a successful lock appears a few
millis later. For reference, description from <vdr/device.h>

         ///< Returns true if the device has a lock on the requested transponder.
         ///< Default is true, a specific device implementation may return false
         ///< to indicate that it is not ready yet.
         ///< If TimeoutMs is not zero, waits for the given number of milliseconds
         ///< before returning false.

Default behaviour for timeoutMsP == 0 is preserved.

cheers,
Winfried